### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 streamlit==1.5.0
+click==8.0.3


### PR DESCRIPTION
running this app in Gitpod via

```streamlit run streamlit_app.py```

results in an error

```
Traceback (most recent call last):
  File "/home/gitpod/.pyenv/versions/3.8.12/bin/streamlit", line 8, in <module>
    sys.exit(main())
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/site-packages/streamlit/cli.py", line 202, in main_run
    _main_run(target, args, flag_options=kwargs)
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/site-packages/streamlit/cli.py", line 228, in _main_run
    command_line = _get_command_line_as_string()
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/site-packages/streamlit/cli.py", line 217, in _get_command_line_as_string
    cmd_line_as_list.extend(click.get_os_args())
AttributeError: module 'click' has no attribute 'get_os_args'
```

Pinning the version of click should work to fix this issue 
https://github.com/streamlit/streamlit/issues/4555